### PR TITLE
[ENG-12870] - A POC on how to run specific seeds based on specific instances

### DIFF
--- a/lib/generators/seed_migration/seed_migration_generator.rb
+++ b/lib/generators/seed_migration/seed_migration_generator.rb
@@ -7,10 +7,16 @@ module SeedMigration
       namespace 'seed_migration'
       desc 'Creates a seed migration'
       class_option :migration_name, :type => :string, :default => nil
+      class_option :migration_instance_folder, :type => :string, :default => nil
+
       argument :timestamp, :type => :string, :required => false, :default => Time.now.utc.strftime("%Y%m%d%H%M%S")
 
       def create_seed_migration_file
-        path = SeedMigration::Migrator.data_migration_directory
+        if SeedMigration.force_app_instance_migrations? && !options['migration_instance_folder']
+          raise ArgumentError, "You must pass the migration_instance_folder param, e.g. rails g seed_migration migration_instance_folder=base"
+        end
+
+        path = SeedMigration::Migrator.data_migration_directory(options['migration_instance_folder'])
         create_file path.join("#{timestamp}_#{file_name.gsub(/([A-Z])/, '_\1').downcase}.rb"), contents
       end
 

--- a/lib/generators/seed_migration/seed_migration_generator.rb
+++ b/lib/generators/seed_migration/seed_migration_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails/generators'
 require 'rails/generators/named_base'
 
@@ -7,17 +9,18 @@ module SeedMigration
       namespace 'seed_migration'
       desc 'Creates a seed migration'
       class_option :migration_name, :type => :string, :default => nil
-      class_option :migration_instance_folder, :type => :string, :default => nil
+      class_option :seed_directory, type: :string, default: nil, desc: 'The directory where this seed file is going to be created. By --seed_directory=data, it will create it inside db/data directory. By --seed_directory=<any>, it will create it inside db/<any> custom directory.'
 
       argument :timestamp, :type => :string, :required => false, :default => Time.now.utc.strftime("%Y%m%d%H%M%S")
 
       def create_seed_migration_file
-        if SeedMigration.force_app_instance_migrations? && !options['migration_instance_folder']
-          raise ArgumentError, "You must pass the migration_instance_folder param, e.g. rails g seed_migration migration_instance_folder=base"
+        if SeedMigration.seeds_by_custom_directories_enabled? && !options['seed_directory']
+          Logger.new($stdout).error "Can't execute seed_migration. You must pass the seed_directory param, e.g. bundle exec rails generate seed_migration seed_directory=data. \
+This requirement is currently enabled by SeedMigration.config.seed_by_custom_directories == true. Run 'bundle exec rails g seed_migration' for details."
+        else
+          path = SeedMigration::Migrator.data_migration_directory(options['seed_directory'])
+          create_file path.join("#{timestamp}_#{file_name.gsub(/([A-Z])/, '_\1').downcase}.rb"), contents
         end
-
-        path = SeedMigration::Migrator.data_migration_directory(options['migration_instance_folder'])
-        create_file path.join("#{timestamp}_#{file_name.gsub(/([A-Z])/, '_\1').downcase}.rb"), contents
       end
 
       private

--- a/lib/seed_migration/engine.rb
+++ b/lib/seed_migration/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails'
 
 module SeedMigration
@@ -11,7 +13,7 @@ module SeedMigration
   mattr_accessor :migrations_path
   mattr_accessor :use_strict_create
   mattr_accessor :use_activerecord_import
-  mattr_accessor :force_migration_instance_folders
+  mattr_accessor :seed_by_custom_directories
 
   self.migration_table_name = DEFAULT_TABLE_NAME
   self.extend_native_migration_task = false
@@ -20,7 +22,7 @@ module SeedMigration
   self.migrations_path = 'data'
   self.use_strict_create = false
   self.use_activerecord_import = false
-  self.force_migration_instance_folders = false
+  self.seed_by_custom_directories = false
 
   def self.config
     yield self
@@ -28,7 +30,7 @@ module SeedMigration
   end
 
   def self.after_config
-    if self.extend_native_migration_task
+    if extend_native_migration_task
       require_relative '../extra_tasks.rb'
     end
   end
@@ -41,11 +43,12 @@ module SeedMigration
     use_activerecord_import
   end
 
-  def self.force_migration_instance_folders?
-    force_migration_instance_folders
+  def self.seeds_by_custom_directories_enabled?
+    seed_by_custom_directories
   end
 
   class Engine < ::Rails::Engine
+
     isolate_namespace SeedMigration
 
     config.generators do |g|
@@ -56,4 +59,5 @@ module SeedMigration
     end
 
   end
+
 end

--- a/lib/seed_migration/engine.rb
+++ b/lib/seed_migration/engine.rb
@@ -11,7 +11,7 @@ module SeedMigration
   mattr_accessor :migrations_path
   mattr_accessor :use_strict_create
   mattr_accessor :use_activerecord_import
-  mattr_accessor :force_instance_type
+  mattr_accessor :force_migration_instance_folders
 
   self.migration_table_name = DEFAULT_TABLE_NAME
   self.extend_native_migration_task = false
@@ -20,7 +20,7 @@ module SeedMigration
   self.migrations_path = 'data'
   self.use_strict_create = false
   self.use_activerecord_import = false
-  self.force_instance_type = false
+  self.force_migration_instance_folders = false
 
   def self.config
     yield self
@@ -39,6 +39,10 @@ module SeedMigration
 
   def self.use_activerecord_import?
     use_activerecord_import
+  end
+
+  def self.force_migration_instance_folders?
+    force_migration_instance_folders
   end
 
   class Engine < ::Rails::Engine

--- a/lib/seed_migration/engine.rb
+++ b/lib/seed_migration/engine.rb
@@ -11,6 +11,7 @@ module SeedMigration
   mattr_accessor :migrations_path
   mattr_accessor :use_strict_create
   mattr_accessor :use_activerecord_import
+  mattr_accessor :force_instance_type
 
   self.migration_table_name = DEFAULT_TABLE_NAME
   self.extend_native_migration_task = false
@@ -19,6 +20,7 @@ module SeedMigration
   self.migrations_path = 'data'
   self.use_strict_create = false
   self.use_activerecord_import = false
+  self.force_instance_type = false
 
   def self.config
     yield self


### PR DESCRIPTION
We should be able to run specific seed migrations for the ADAC instance. It's a requirement from product. For now we're resolving it with var env check for `ADAC` specific seeds, see: https://github.com/joinswoop/swoop/blob/master/db/data/20190918194920_add_pls_settings_for_nissan_eu.rb#L3

But this approach may not be the best solution, as one can forget to add that env var check in the seed (it happened already, but got fixed before the release). Apparently we haven't discussed exactly on how we should be doing it, if not by env var check (as far as I know).

This PR is just a POC on how we could it by extending the seed_migration gem. In this approach, it will only create a new seed file if a given `--seed_directory` is passed as param, and it will only migrate the seeds for the given `seeds_directories` param.

Take a look:

```ruby
# swoop system initializer/seed_migration.rb

SeedMigration.config do |c|
  c.seed_by_custom_directories = true # enable this new conf
end

```

Then to create a new seed:

```ruby
bundle exec rails g seed_migration AddClientProgramToNissan --seed_directory=data
# => will create db/data/20190924201010_add_client_program_to_lincoln.rb

bundle exec rails g seed_migration AddClientProgramToNissan --seed_directory=adac
# => will create db/data/adac/20190924201010_add_client_program_to_adac_nissan.rb
# (note the dir: db/data/*adac*)

# if --seed_directory is not passed, raise it back:
bundle exec rails g seed_migration AddBla
# => ERROR -- : Can't execute seed_migration. You must pass the seed_directory param, e.g. bundle exec rails generate seed_migration seed_directory=data.
# so devs will be forced to pass --seed_directory always
```

To migrate:

```ruby
rake seed:migrate --seed_directories=data
# => will only execute db/data/20190924201010_add_client_program_to_lincoln.rb (say, for Swoop US)

# or if we want seeds from both dirs
rake seed:migrate --seed_directories=data,adac
# => will execute
#  db/data/20190924201010_add_client_program_to_lincoln.rb
#  db/data/adac/20190924201010_add_client_program_to_adac_nissan.rb

# if we had a third dir
rake seed:migrate --seed_directories=data,adac,japan_instance
# => will execute
#  db/data/20190924201010_add_client_program_to_lincoln.rb
#  db/data/adac/20190924201010_add_client_program_to_adac_nissan.rb
#  db/data/japan_instance/<whatever.rb>

# if --seed_directories is not passed, raise error
rake seed:migrate
# => ERROR -- : Can't execute seeds:migrate. You must pass the seeds_directories param, e.g. bundle exec seed:migrate seeds_directories=data,adac.
# => on local envs, we can just run it all if Rails.env.develpment? (not implemented yet)
```

`seed:rollback` would work the same way as it currently works, I just added support for it to read from all subdirs inside `db/data`

Then on CircleCI we can tune the `seed:migrate` command to only run the specific seeds we want in determined instances. Yeah, for now it's only **Swoop US** or **ADAC**.

@lamtha @modosc @netsprout  **I'd love to hear your opinion about this**, please let me know if this is something we should continue investing more time. There will be some more tweaks to add, and specs. And we'll need a way to test it, which can be a problem since we don't have beta and stg envs for ADAC.