### PR TITLE
[ENG-16646] - Add support to set environments on seed migrations

### DIFF
--- a/lib/seed_migration/engine.rb
+++ b/lib/seed_migration/engine.rb
@@ -4,6 +4,14 @@ module SeedMigration
 
   DEFAULT_TABLE_NAME = 'seed_migration_data_migrations'
 
+  # Default environments list set, defaults to []
+  mattr_accessor :environments_defaults
+  # set the current enviroment rails value, defaults to Rails.env
+  mattr_accessor :environments_rails_value
+  # set if the environments method should explicitly be called in the seeds, defaults to false
+  mattr_accessor :environments_required
+  # set the seed version from where the environments check should start, defaults to nil (which will check it from the first seed file)
+  mattr_accessor :environments_version_bootstrap
   mattr_accessor :extend_native_migration_task
   mattr_accessor :migration_table_name
   mattr_accessor :ignore_ids
@@ -12,6 +20,10 @@ module SeedMigration
   mattr_accessor :use_strict_create
   mattr_accessor :use_activerecord_bulk_insert
 
+  self.environments_defaults = []
+  self.environments_rails_value = Rails.env
+  self.environments_required = false
+  self.environments_version_bootstrap = nil
   self.migration_table_name = DEFAULT_TABLE_NAME
   self.extend_native_migration_task = false
   self.ignore_ids = false
@@ -37,6 +49,10 @@ module SeedMigration
 
   def self.use_activerecord_bulk_insert?
     use_activerecord_bulk_insert
+  end
+
+  def self.environments_required?
+    environments_required
   end
 
   class Engine < ::Rails::Engine

--- a/lib/seed_migration/environments.rb
+++ b/lib/seed_migration/environments.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#
+# Define instance and class methods to manage migration environments
+# on the seed migration files
+#
+# This module is included by SeedMigration::Migration, so its
+# methods are available to all seed migration files.
+#
+module Environments
+  # Class methods
+  module ClassMethods
+    attr_reader :environment_names_array
+
+    # Difine environments to apply the seed migration
+    #
+    # class MyMigration < SeedMigration::Migration
+    #
+    #   environments :production-us, :production-eu
+    #
+    #   def up
+    #   end
+    #
+    #   def down
+    #   end
+    # end
+    #
+    def environments(*environment_names)
+      @environment_names_array = environment_names
+    end
+  end
+
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+end

--- a/lib/seed_migration/environments.rb
+++ b/lib/seed_migration/environments.rb
@@ -12,7 +12,7 @@ module Environments
   module ClassMethods
     attr_reader :environment_names_array
 
-    # Difine environments to apply the seed migration
+    # Define environments to apply the seed migration
     #
     # class MyMigration < SeedMigration::Migration
     #

--- a/lib/seed_migration/migration.rb
+++ b/lib/seed_migration/migration.rb
@@ -1,5 +1,11 @@
+# frozen_string_literal: true
+
+require_relative 'environments'
+
 module SeedMigration
   class Migration
+    include Environments
+
     def up
       raise NotImplementedError
     end

--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -23,11 +23,17 @@ module SeedMigration
       klass = class_from_path
       version, _ = self.class.parse_migration_filename(@path)
       raise "#{klass} has already been migrated." if SeedMigration::DataMigration.where(version: version).first
+      raise_if_missing_required_environments(klass, version)
 
       start_time = Time.now
       announce("#{klass}: migrating")
       ActiveRecord::Base.transaction do
-        klass.new.up
+        if should_apply_in_this_environment?(klass, version)
+          klass.new.up
+        else
+          announce("#{klass} not applied in this environment, #{klass} required environments: #{default_and_seed_environments(klass)}, current environment: #{SeedMigration.environments_rails_value}")
+        end
+
         end_time = Time.now
         runtime = (end_time - start_time).to_d.round(2)
 
@@ -41,7 +47,11 @@ module SeedMigration
         rescue StandardError => e
           SeedMigration::Migrator.logger.error e
         end
-        announce("#{klass}: migrated (#{runtime}s)")
+        if should_apply_in_this_environment?(klass, version)
+          announce("#{klass}: migrated (#{runtime}s)")
+        else
+          announce("#{klass}: version recorded to #{SeedMigration.migration_table_name} table just for rollback consistency (#{runtime}s)")
+        end
       end
     end
 
@@ -66,6 +76,54 @@ module SeedMigration
         # Delete record of migration
         migration.destroy
         announce("#{klass}: reverted (#{runtime}s)")
+      end
+    end
+
+    def should_apply_in_this_environment?(klass, version)
+      @should_apply_in_this_environment ||=
+        (!SeedMigration.environments_required? || !seed_version_requires_environment?(version) || default_and_seed_environments(klass).map(&:to_s).include?(SeedMigration.environments_rails_value))
+    end
+
+    def default_and_seed_environments(klass)
+      return @default_and_seed_environments if @default_and_seed_environments
+
+      if [nil, Array].exclude?(SeedMigration.environments_defaults.class)
+        raise 'SeedMigration.environments invalid, it should be an array'
+      end
+
+      @default_and_seed_environments ||= (SeedMigration.environments_defaults | klass.environment_names_array).map(&:to_s)
+    end
+
+    def seed_version_requires_environment?(version)
+      seed_version_requires_environment = !SeedMigration.environments_version_bootstrap ||
+          (SeedMigration.environments_version_bootstrap && SeedMigration.environments_version_bootstrap < version)
+    end
+
+    def raise_if_missing_required_environments(klass, version)
+      if SeedMigration.environments_required?
+        if seed_version_requires_environment?(version) && klass.environment_names_array.blank?
+          msg = [
+            "Missing environments declaration for: #{@path}",
+            "\nPlease add it like:",
+            <<~SEED
+
+              class MySeedMigration < SeedMigration::Migration
+
+                # in this example, it will apply it on both production and adac_production envs
+                environments :production, :adac_production
+
+                def up
+                end
+
+                def down
+                end
+
+              end
+
+            SEED
+          ].join("\n")
+          raise msg
+        end
       end
     end
 
@@ -231,7 +289,7 @@ module SeedMigration
       basename = File.basename(filename, '.rb')
       _, version, underscored_name = basename.match(/(\d+)_(.*)/).to_a
       name = underscored_name.gsub("_", " ").capitalize
-      [version, name]
+      [version, name, basename]
     end
 
     def self.create_seed_file


### PR DESCRIPTION
**DO NOT MERGE** before https://github.com/joinswoop/swoop/pull/13462

With this PR, we are now able to require the environments where a migration should run into, and raise error in case it doesn't have the environments set.

### specs
I swear I tried to add specs to it, but the current specs setup on this repo is a bit complex; it requires a db setup. Before this PR, the codebase already had changes for the Swoop setup (basically made by Jon I think) and also didn't have specs updated. Not sure how to proceed here since I don't expect us to keep using it so often going forward, so decided not to bother with specs for for now (ugh). But since we still need to make sure we don't screw with ADAC data, I think this PR is still worth it. I tested it ostensively locally.

### How to use

On Swoop (or PLS) `initializer/seed_migration.rb`, we should just add:

```ruby
SeedMigration.config do |c|
    # set the default envs where it should be applied
    c.environments_defaults = :development, :beta, :staging
    # set the env value that should be checked (Rails.swoop_env in our case)
    c.environments_rails_value = Rails.swoop_env
    # require environments to be set on the seed files
    c.environments_required = true
    # set the seed migration from where the environments should start being required
    c.environments_version_bootstrap = '20200813183517'
  end
```

and on the seed migrations:

```ruby
class MyMigration < SeedMigration::Migration
  environments :production, :adac_production # or only :production if it should exclude adac, for instance
   
  def up
  end
    
  def down
  end
end
```

It should not change the current seeds behaviour if merged into master, unless we setup the `SeedMigration.config` that I shown ^ ^, since swoop (and PLS) does not require the environments to be set in their seed_migration.rb initializer config.