### PR TITLE
Disable transaction by default since it can be dangerous on large tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,14 +210,19 @@ end
 ## Disable Transactions
 
 Support has been added for disabling transactions for long running migrations.
+Since a long running migration can lock a table in production, transactions are
+disabled by default. You should always try to write idempotent migrations,
+but if you can't, you can either add transaction blocks manually in your migration,
+or if you just want to enable a transaction around the whole migration, you can
+call `use_transaction!`.
 
 ```ruby
 class ChangeABunchOfJobs < SeedMigration::Migration
 
-  disable_transaction!
+  use_transaction!
 
   def up
-    Job.all.in_batches.update_all(awesome: true)
+    ...
   end
 
   def down

--- a/lib/seed_migration/migration.rb
+++ b/lib/seed_migration/migration.rb
@@ -7,17 +7,18 @@ module SeedMigration
     include Environments
 
     class << self
-      attr_accessor :transaction_disabled
+      attr_accessor :transaction_enabled
+
       # Disable the transaction wrapping this migration.
       # You can still create your own transactions even after
       # calling #disable_transaction!
-      def disable_transaction!
-        @transaction_disabled = true
+      def use!
+        @transaction_enabled = true
       end
     end
 
-    def transaction_disabled?
-      self.class.transaction_disabled
+    def transaction_enabled?
+      self.class.transaction_enabled
     end
 
     def up

--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -90,12 +90,12 @@ module SeedMigration
     end
 
     def transaction(klass)
-      if transaction_disabled?
-        yield
-      else
+      if transaction_enabled
         ActiveRecord::Base.transaction do
           yield
         end
+      else
+        yield
       end
     end
 


### PR DESCRIPTION
We've had several incidences where the implicit transaction around a data migration locked a table in production for several minutes. We're removing this transaction by default since it's too easy to let these kinds of things slip through since the code gives no indication that it will do that unless you know the inner working of this gem.